### PR TITLE
Roctracer: Enable individual activity types (#772)

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -25,6 +25,28 @@ static timestamp_t timespec_to_ns(const timespec& time) {
 
 using namespace std::chrono;
 
+// Local copy of hip op types.  These are public (and stable) in later rocm releases
+typedef enum {
+  HIP_OP_COPY_KIND_UNKNOWN_ = 0,
+  HIP_OP_COPY_KIND_DEVICE_TO_HOST_ = 0x11F3,
+  HIP_OP_COPY_KIND_HOST_TO_DEVICE_ = 0x11F4,
+  HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_ = 0x11F5,
+  HIP_OP_COPY_KIND_DEVICE_TO_HOST_2D_ = 0x1201,
+  HIP_OP_COPY_KIND_HOST_TO_DEVICE_2D_ = 0x1202,
+  HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_2D_ = 0x1203,
+  HIP_OP_COPY_KIND_FILL_BUFFER_ = 0x1207
+} hip_op_copy_kind_t_;
+
+typedef enum {
+  HIP_OP_DISPATCH_KIND_UNKNOWN_ = 0,
+  HIP_OP_DISPATCH_KIND_KERNEL_ = 0x11F0
+} hip_op_dispatch_kind_t_;
+
+typedef enum {
+  HIP_OP_BARRIER_KIND_UNKNOWN_ = 0
+} hip_op_barrier_kind_t_;
+// end hip op defines
+
 namespace KINETO_NAMESPACE {
 
 constexpr size_t kBufSize(2 * 1024 * 1024);
@@ -66,7 +88,11 @@ void RoctracerActivityApi::setMaxBufferSize(int size) {
 }
 
 inline bool inRange(int64_t start, int64_t end, int64_t stamp) {
-    return ((stamp > start) && (stamp < end));
+  return ((stamp > start) && (stamp < end));
+}
+
+inline bool RoctracerActivityApi::isLogged(libkineto::ActivityType atype) {
+  return activityMaskSnapshot_ & (1 << static_cast<uint32_t>(atype));
 }
 
 int RoctracerActivityApi::processActivities(
@@ -92,145 +118,148 @@ int RoctracerActivityApi::processActivities(
 
   // Basic Api calls
 
-  for (auto &item : d->rows_) {
-    if (!inRange(startTime, endTime, item.begin))
-        continue;
-    GenericTraceActivity a;
-    a.startTime = (item.begin + toffset) / 1000;
-    a.endTime = (item.end + toffset) / 1000;
-    a.id = item.id;
-    a.device = item.pid;
-    a.resource = item.tid;
-    a.activityType = ActivityType::CUDA_RUNTIME;
-    a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
-    a.flow.id = item.id;
-    a.flow.type = kLinkAsyncCpuGpu;
-    a.flow.start = true;
+  if (isLogged(ActivityType::CUDA_RUNTIME)) {
 
-    auto it = externalCorrelations.find(a.id);
-    a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
+    for (auto &item : d->rows_) {
+      if (!inRange(startTime, endTime, item.begin))
+          continue;
+      GenericTraceActivity a;
+      a.startTime = (item.begin + toffset) / 1000;
+      a.endTime = (item.end + toffset) / 1000;
+      a.id = item.id;
+      a.device = item.pid;
+      a.resource = item.tid;
+      a.activityType = ActivityType::CUDA_RUNTIME;
+      a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+      a.flow.id = item.id;
+      a.flow.type = kLinkAsyncCpuGpu;
+      a.flow.start = true;
 
-    logger.handleGenericActivity(a);
-    ++count;
-  }
+      auto it = externalCorrelations.find(a.id);
+      a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
 
-  // Malloc/Free calls
-  for (auto &item : d->mallocRows_) {
-    if (!inRange(startTime, endTime, item.begin))
-        continue;
-    GenericTraceActivity a;
-    a.startTime = (item.begin + toffset) / 1000;
-    a.endTime = (item.end + toffset) / 1000;
-    a.id = item.id;
-    a.device = item.pid;
-    a.resource = item.tid;
-    a.activityType = ActivityType::CUDA_RUNTIME;
-    a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
-    a.flow.id = item.id;
-    a.flow.type = kLinkAsyncCpuGpu;
-    a.flow.start = true;
-
-    auto it = externalCorrelations.find(a.id);
-    a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
-
-    a.addMetadataQuoted("ptr", fmt::format("{}", item.ptr));
-    if (item.cid == HIP_API_ID_hipMalloc) {
-      a.addMetadata("size", item.size);
+      logger.handleGenericActivity(a);
+      ++count;
     }
 
-    logger.handleGenericActivity(a);
-    ++count;
-  }
+    // Malloc/Free calls
+    for (auto &item : d->mallocRows_) {
+      if (!inRange(startTime, endTime, item.begin))
+          continue;
+      GenericTraceActivity a;
+      a.startTime = (item.begin + toffset) / 1000;
+      a.endTime = (item.end + toffset) / 1000;
+      a.id = item.id;
+      a.device = item.pid;
+      a.resource = item.tid;
+      a.activityType = ActivityType::CUDA_RUNTIME;
+      a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+      a.flow.id = item.id;
+      a.flow.type = kLinkAsyncCpuGpu;
+      a.flow.start = true;
 
-  // HipMemcpy calls
-  for (auto &item : d->copyRows_) {
-    if (!inRange(startTime, endTime, item.begin))
-        continue;
-    GenericTraceActivity a;
-    a.startTime = (item.begin + toffset) / 1000;
-    a.endTime = (item.end + toffset) / 1000;
-    a.id = item.id;
-    a.device = item.pid;
-    a.resource = item.tid;
-    a.activityType = ActivityType::CUDA_RUNTIME;
-    a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
-    a.flow.id = item.id;
-    a.flow.type = kLinkAsyncCpuGpu;
-    a.flow.start = true;
+      auto it = externalCorrelations.find(a.id);
+      a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
 
-    auto it = externalCorrelations.find(a.id);
-    a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
-
-    a.addMetadataQuoted("src", fmt::format("{}", item.src));
-    a.addMetadataQuoted("dst", fmt::format("{}", item.dst));
-    a.addMetadata("size", item.size);
-    a.addMetadata("kind", item.kind);
-    if ((item.cid == HIP_API_ID_hipMemcpyAsync) || (item.cid == HIP_API_ID_hipMemcpyWithStream)) {
-      a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
-    }
-
-    logger.handleGenericActivity(a);
-    ++count;
-  }
-
-  // Kernel Launch Api calls
-
-  for (auto &item : d->kernelRows_) {
-    if (!inRange(startTime, endTime, item.begin))
-        continue;
-    GenericTraceActivity a;
-    a.startTime = (item.begin + toffset) / 1000;
-    a.endTime = (item.end + toffset) / 1000;
-    a.id = item.id;
-    a.device = item.pid;
-    a.resource = item.tid;
-    a.activityType = ActivityType::CUDA_RUNTIME;
-    a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
-    a.flow.id = item.id;
-    a.flow.type = kLinkAsyncCpuGpu;
-    a.flow.start = true;
-
-    auto it = externalCorrelations.find(a.id);
-    a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
-
-    // TODO: Use lowercase kernel, once legacy tools update.
-    if (item.functionAddr != nullptr) {
-      a.addMetadataQuoted(
-          "Kernel", demangle(hipKernelNameRefByPtr(item.functionAddr, item.stream)));
-    }
-    else if (item.function != nullptr) {
-      a.addMetadataQuoted(
-          "Kernel", demangle(hipKernelNameRef(item.function)));
-    }
-    a.addMetadata("grid dim", fmt::format("[{}, {}, {}]", item.gridX, item.gridY, item.gridZ));
-    a.addMetadata("block dim", fmt::format("[{}, {}, {}]", item.workgroupX, item.workgroupY, item.workgroupZ));
-    a.addMetadata("shared size", item.groupSegmentSize);
-    a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
-
-    // Stash launches to tie to the async ops
-    kernelLaunches_[a.id] = a;
-
-    // Stash kernel names to tie to the async ops
-    std::string name;
-    if (item.functionAddr != nullptr) {
-      name = demangle(hipKernelNameRefByPtr(item.functionAddr, item.stream));
-    }
-    else if (item.function != nullptr) {
-      name = demangle(hipKernelNameRef(item.function));
-    }
-    if (!name.empty()) {
-      uint32_t string_id = reverseStrings_[name];
-      if (string_id == 0) {
-        string_id = nextStringId_++;
-        reverseStrings_[name] = string_id;
-        strings_[string_id] = name;
+      a.addMetadataQuoted("ptr", fmt::format("{}", item.ptr));
+      if (item.cid == HIP_API_ID_hipMalloc) {
+        a.addMetadata("size", item.size);
       }
-      kernelNames_[item.id] = string_id;
+
+      logger.handleGenericActivity(a);
+      ++count;
     }
 
-    logger.handleGenericActivity(a);
-    ++count;
-  }
+    // HipMemcpy calls
+    for (auto &item : d->copyRows_) {
+      if (!inRange(startTime, endTime, item.begin))
+          continue;
+      GenericTraceActivity a;
+      a.startTime = (item.begin + toffset) / 1000;
+      a.endTime = (item.end + toffset) / 1000;
+      a.id = item.id;
+      a.device = item.pid;
+      a.resource = item.tid;
+      a.activityType = ActivityType::CUDA_RUNTIME;
+      a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+      a.flow.id = item.id;
+      a.flow.type = kLinkAsyncCpuGpu;
+      a.flow.start = true;
+
+      auto it = externalCorrelations.find(a.id);
+      a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
+
+      a.addMetadataQuoted("src", fmt::format("{}", item.src));
+      a.addMetadataQuoted("dst", fmt::format("{}", item.dst));
+      a.addMetadata("size", item.size);
+      a.addMetadata("kind", item.kind);
+      if ((item.cid == HIP_API_ID_hipMemcpyAsync) || (item.cid == HIP_API_ID_hipMemcpyWithStream)) {
+        a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
+      }
+
+      logger.handleGenericActivity(a);
+      ++count;
+    }
+
+    // Kernel Launch Api calls
+
+    for (auto &item : d->kernelRows_) {
+      if (!inRange(startTime, endTime, item.begin))
+          continue;
+      GenericTraceActivity a;
+      a.startTime = (item.begin + toffset) / 1000;
+      a.endTime = (item.end + toffset) / 1000;
+      a.id = item.id;
+      a.device = item.pid;
+      a.resource = item.tid;
+      a.activityType = ActivityType::CUDA_RUNTIME;
+      a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+      a.flow.id = item.id;
+      a.flow.type = kLinkAsyncCpuGpu;
+      a.flow.start = true;
+
+      auto it = externalCorrelations.find(a.id);
+      a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
+
+      // TODO: Use lowercase kernel, once legacy tools update.
+      if (item.functionAddr != nullptr) {
+        a.addMetadataQuoted(
+            "Kernel", demangle(hipKernelNameRefByPtr(item.functionAddr, item.stream)));
+      }
+      else if (item.function != nullptr) {
+        a.addMetadataQuoted(
+            "Kernel", demangle(hipKernelNameRef(item.function)));
+      }
+      a.addMetadata("grid dim", fmt::format("[{}, {}, {}]", item.gridX, item.gridY, item.gridZ));
+      a.addMetadata("block dim", fmt::format("[{}, {}, {}]", item.workgroupX, item.workgroupY, item.workgroupZ));
+      a.addMetadata("shared size", item.groupSegmentSize);
+      a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
+
+      // Stash launches to tie to the async ops
+      kernelLaunches_[a.id] = a;
+
+      // Stash kernel names to tie to the async ops
+      std::string name;
+      if (item.functionAddr != nullptr) {
+        name = demangle(hipKernelNameRefByPtr(item.functionAddr, item.stream));
+      }
+      else if (item.function != nullptr) {
+        name = demangle(hipKernelNameRef(item.function));
+      }
+      if (!name.empty()) {
+        uint32_t string_id = reverseStrings_[name];
+        if (string_id == 0) {
+          string_id = nextStringId_++;
+          reverseStrings_[name] = string_id;
+          strings_[string_id] = name;
+        }
+        kernelNames_[item.id] = string_id;
+      }
+
+      logger.handleGenericActivity(a);
+      ++count;
+    }
+  }  // isLogged(ActivityType::CUDA_RUNTIME)
 
   // Async Ops
 
@@ -292,7 +321,35 @@ int RoctracerActivityApi::processActivities(
           a.activityName = strings_[it->second];
         }
 
-        if (inRange(startTime, endTime, record->begin_ns)) {
+        bool filtered = false;
+
+        switch (record->kind) {
+          case HIP_OP_COPY_KIND_DEVICE_TO_HOST_:
+          case HIP_OP_COPY_KIND_HOST_TO_DEVICE_:
+          case HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_:
+          case HIP_OP_COPY_KIND_DEVICE_TO_HOST_2D_:
+          case HIP_OP_COPY_KIND_HOST_TO_DEVICE_2D_:
+          case HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_2D_:
+            if (!isLogged(ActivityType::GPU_MEMCPY))
+              filtered = true;
+            a.activityType = ActivityType::GPU_MEMCPY;
+            break;
+          case HIP_OP_COPY_KIND_FILL_BUFFER_:
+            if (!isLogged(ActivityType::GPU_MEMSET))
+              filtered = true;
+            a.activityType = ActivityType::GPU_MEMSET;
+            break;
+          case HIP_OP_DISPATCH_KIND_KERNEL_:
+          default:
+            if (!isLogged(ActivityType::CONCURRENT_KERNEL))
+              filtered = true;
+            if (record->op == HIP_OP_ID_BARRIER)  // Don't record barriers/markers
+              filtered = true;
+            a.activityType = ActivityType::CONCURRENT_KERNEL;
+            break;
+        }
+
+        if (!filtered && inRange(startTime, endTime, record->begin_ns)) {
             logger.handleGenericActivity(a);
             ++count;
         }
@@ -315,6 +372,7 @@ void RoctracerActivityApi::enableActivities(
   d->startLogging();
 
   for (const auto& activity : selected_activities) {
+    activityMask_ |= (1 << static_cast<uint32_t>(activity));
     if (activity == ActivityType::EXTERNAL_CORRELATION) {
         d->externalCorrelationEnabled_ = true;
     }
@@ -327,7 +385,10 @@ void RoctracerActivityApi::disableActivities(
 #ifdef HAS_ROCTRACER
   d->stopLogging();
 
+  activityMaskSnapshot_ = activityMask_;
+
   for (const auto& activity : selected_activities) {
+    activityMask_ &= ~(1 << static_cast<uint32_t>(activity));
     if (activity == ActivityType::EXTERNAL_CORRELATION) {
         d->externalCorrelationEnabled_ = false;
     }

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -72,6 +72,11 @@ class RoctracerActivityApi {
 
   std::map<activity_correlation_id_t, GenericTraceActivity> kernelLaunches_;
 
+  // Enabled Activity Filters
+  uint32_t activityMask_{0};
+  uint32_t activityMaskSnapshot_{0};
+  bool isLogged(libkineto::ActivityType atype);
+
   RoctracerLogger *d;
 };
 


### PR DESCRIPTION
Cherry-picked the fix from the commit in rocm5.7_internal_testing to fix this unit test in release/2.0 branch:

profiler/test_profiler.py: test_kineto (main.TestProfiler)

Summary:
RoctracerActivityApi was logging api, op, and correlation data whenever enabled, i.e. all-or-nothing.  This caused failures in some unit tests which wanted to see that kernels were enqueued (CUDA_RUNTIME) but insisted it didn't see them run (CONCURRENT_KERNEL).

Now we are correctly identifying GPU_MEMCPY, GPU_MEMSET, and CONCURRENT_KERNEL activity.  This is done via replicating an enum that was previously internal but stable.  It will be public in future rocm releases.  The names will not collide.

Also, Roctracer reports barrier/marker ops that run on the gpu while CUPTI does not.  We now suppress these as they are pretty noisy with very little value.

Addresses https://github.com/pytorch/pytorch/issues/97167

Pull Request resolved: https://github.com/pytorch/kineto/pull/772

Reviewed By: chaekit

Differential Revision: D47641901

Pulled By: aaronenyeshi

fbshipit-source-id: cbec0e08ad22f4bcfd0e3e87fb096a920deb40c7